### PR TITLE
Avoid creating a new array on each operation in worst case

### DIFF
--- a/pqueue.go
+++ b/pqueue.go
@@ -49,7 +49,7 @@ func (pq *PriorityQueue) Push(x interface{}) {
 func (pq *PriorityQueue) Pop() interface{} {
 	n := len(*pq)
 	c := cap(*pq)
-	if n < (c/2) && c > 25 {
+	if n < (c/4) && c > 25 {
 		npq := make(PriorityQueue, n, c/2)
 		copy(npq, *pq)
 		*pq = npq


### PR DESCRIPTION
The pop method could be too expensive in worst case: 
- Consider push-pop-push-pop ... sequence when array is full
- Each operation takes time proportional to N

We can shrink : half size of array when array is one-quarter full
